### PR TITLE
Replace time stepper in Simulation with timestep cache and add euler step method

### DIFF
--- a/src/models/abstract_model.jl
+++ b/src/models/abstract_model.jl
@@ -71,6 +71,11 @@ Returns the time stepping scheme associated with this `model`.
 """
 get_initializer(model::AbstractModel) = model.initializer
 
+"""
+Convenience dispatch for `timestep!` that forwards to `timestep!(state, model, get_time_stepping(model), dt)`.
+"""
+timestep!(state, model::AbstractModel, dt) = timestep!(state, model, get_time_stepping(model), dt)
+
 # TODO: define general method interfaces (as needed) for all model types
 
 """

--- a/src/models/soil_model.jl
+++ b/src/models/soil_model.jl
@@ -110,7 +110,7 @@ end
 
 @kernel function timestep_kernel!(
     state,
-    ::ForwardEuler,
+    euler::ForwardEuler,
     energy::AbstractSoilEnergyBalance,
     hydrology::AbstractSoilHydrology,
     strat::AbstractStratigraphy,
@@ -121,7 +121,7 @@ end
     idx = @index(Global, NTuple)
     i, j, k = idx
     # timestep for internal energy
-    state.internal_energy[i, j, k] = state.internal_energy[i, j, k] + dt*state.internal_energy_tendency[i, j, k]
+    state.internal_energy[i, j, k] = step(euler, state.internal_energy[i, j, k], state.internal_energy_tendency[i, j, k], dt)
     # apply inverse closure relation to update temperature
     fc = get_freezecurve(hydrology)
     energy_to_temperature!(idx, state, fc, energy, hydrology, strat, bgc, constants)

--- a/src/models/vegetation_model.jl
+++ b/src/models/vegetation_model.jl
@@ -124,10 +124,10 @@ function timestep!(state, model::VegetationModel, euler::ForwardEuler, dt=get_dt
     return nothing
 end
 
-@kernel function timestep_vegetation_kernel!(state, ::ForwardEuler, dt)
+@kernel function timestep_vegetation_kernel!(state, euler::ForwardEuler, dt)
     i, j = @index(Global, NTuple)
     # Update vegetation carbon pool, compute C_veg(t)
-    state.C_veg[i, j] = state.C_veg[i, j] + dt * state.C_veg_tendency[i, j]
+    state.C_veg[i, j] = step(euler, state.C_veg[i, j], state.C_veg_tendency[i, j], dt)
     # Update vegetation fraction, compute ν(t)
-    state.ν[i, j] = state.ν[i, j] + dt * state.ν_tendency[i, j]
+    state.ν[i, j] = step(euler, state.ν[i, j], state.ν_tendency[i, j], dt)
 end

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -38,7 +38,7 @@ Advance the simulation forward by one timestep.
 timestep!(sim::Simulation) = timestep!(sim, get_dt(sim.time_stepping))
 function timestep!(sim::Simulation, dt)
     reset_tendencies!(sim.state)
-    timestep!(sim.state, sim.model, sim.time_stepping, dt)
+    timestep!(sim.state, sim.model, dt)
     tick_time!(sim.state.clock, dt)
 end
 

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -2,22 +2,22 @@ abstract type AbstractSimulation end
 
 struct Simulation{
     Model<:AbstractModel,
-    TimeStepper<:AbstractTimeStepper,
+    TimeStepperCache<:AbstractTimeStepperCache,
     StateVars<:AbstractStateVariables,
 } <: AbstractSimulation
     "The type of model used for the simulation."
     model::Model
 
-    "The time stepping scheme used by the simulation."
-    time_stepping::TimeStepper
+    cache::TimeStepperCache
 
     "Collection of all state variables defined on the simulation `model`."
     state::StateVars
 end
 
-function initialize(model::AbstractModel, time_stepping=get_time_stepping(model); clock::Clock=Clock(time=0.0))
+function initialize(model::AbstractModel; clock::Clock=Clock(time=0.0))
     state = StateVariables(model, clock)
-    sim = Simulation(model, time_stepping, state)
+    time_stepping_cache = initialize(model, get_time_stepping(model))
+    sim = Simulation(model, time_stepping_cache, state)
     initialize!(sim)
     return sim
 end
@@ -47,11 +47,11 @@ end
 
 Run the simulation by `steps` or a `period` with `dt` timestep size (in seconds or Dates.Period).
 """
-function run!(sim::Simulation; 
-        steps::Union{Int, Nothing} = nothing,
-        period::Union{Period, Nothing} = nothing,
-        dt = get_dt(get_time_stepping(sim.model)))
-
+function run!(sim::Simulation;
+    steps::Union{Int, Nothing} = nothing,
+    period::Union{Period, Nothing} = nothing,
+    dt = get_dt(get_time_stepping(sim.model))
+)
     dt = convert_dt(dt)
     steps = get_steps(steps, period, dt)
 

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -35,7 +35,7 @@ end
 
 Advance the simulation forward by one timestep.
 """
-timestep!(sim::Simulation) = timestep!(sim, get_dt(sim.time_stepping))
+timestep!(sim::Simulation) = timestep!(sim, get_dt(get_time_stepping(sim.model)))
 function timestep!(sim::Simulation, dt)
     reset_tendencies!(sim.state)
     timestep!(sim.state, sim.model, dt)

--- a/src/timesteppers/abstract_timestepper.jl
+++ b/src/timesteppers/abstract_timestepper.jl
@@ -22,3 +22,8 @@ function is_adaptive end
 Advance the model state by one time step, or by `dt` units of time.
 """
 function timestep! end
+
+"""
+Base type for time-stepper state caches.
+"""
+abstract type AbstractTimeStepperCache{NF} end

--- a/src/timesteppers/forward_euler.jl
+++ b/src/timesteppers/forward_euler.jl
@@ -6,9 +6,15 @@ Simple forward Euler time stepping scheme.
     dt::NF = 300.0
 end
 
+struct ForwardEulerCache{NF} <: AbstractTimeStepperCache{NF} end
+
 get_dt(euler::ForwardEuler) = euler.dt
 
 is_adaptive(euler::ForwardEuler) = false
+
+@inline step(::ForwardEuler, progvar, tendency, dt) = progvar + dt*tendency
+
+initialize(::AbstractModel{NF}, ::ForwardEuler) where {NF} = ForwardEulerCache{NF}()
 
 # function timestep!(state, model::AbstractModel, euler::ForwardEuler, dt=get_dt(euler))
 #     # TODO: implement timestep! generically

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ if MAIN_TESTS
         include("state_variables.jl")
     end
     @testset "Timestepping" begin
+        include("timestepping/forward_euler.jl")
         include("timestepping/run_full_model.jl")
     end
     @testset "Soil model and processes" begin

--- a/test/timestepping/forward_euler.jl
+++ b/test/timestepping/forward_euler.jl
@@ -1,0 +1,12 @@
+using Terra
+
+@testset "Forward Euler" begin
+    dt = 10.0
+    euler = ForwardEuler(; dt)
+    @test !is_adaptive(euler)
+    @test get_dt(euler) == dt
+    # Forward Euler is simple so we can just directly test it here
+    progvar = 1.0
+    tendency = 0.1
+    @test Terra.step(euler, progvar, tendency, dt) ≈ progvar + dt*tendency
+end


### PR DESCRIPTION
I realized it's stupid to declare the time stepper again in the SImulation (opens up the possibility of inconsistent timestepper definitions between model and simulation).

What we actually want is for `Simulation` to host a cache type for the timestepper, a bit like SciML does. This will be necessary for more complex timesteppers.

I also updated the existing model time stepping implementations to use a common method implementing the forward Euler timestep.

Resolves #14